### PR TITLE
feat: add github action, refactor dockerfile and docker-compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: Create and publish a container image
+
+on:
+  push:
+    branches: ['main']
+    tags: ['*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for container
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push container image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN pip install pipenv --no-cache-dir && \
     pipenv install --system --deploy && \
     pip uninstall -y pipenv virtualenv-clone virtualenv
 
-COPY . $WORKDIR
+COPY main.py .
 
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Go ask plurk a bot token, an account.
 Install **docker**.
 
 ```
-docker-compose up -d --build
+docker-compose up -d
 ```
 
 If no, install **pipenv**.
@@ -20,7 +20,6 @@ If no, install **pipenv**.
 ```
 pipenv run python main.py
 ```
-
 
 Nothing more.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   plurk_bot:
     environment:
       TZ: "Asia/Taipei"
-    build: .
     volumes:
-      - ./data:/app/data
-    image: siaosihbot:latest
+      - ./token.txt:/app/token.txt
+    image: ghcr.io/dephilia/siaosih_bot:latest


### PR DESCRIPTION
We can leverage the Github Package container registry without any extra credentials.

If you consider using Docker Hub or both, I can adjust this workflow.